### PR TITLE
Warning user if constraint function doesn't return a value

### DIFF
--- a/paseos/activities/activity_runner.py
+++ b/paseos/activities/activity_runner.py
@@ -96,22 +96,28 @@ class ActivityRunner:
             bool: True if still valid.
         """
         if self.has_constraint():
-            logger.trace(f"Checking activity {self.name} constraints")
+            logger.debug(f"Checking activity {self.name} constraints")
             try:
                 is_satisfied = await self._constraint_func(self._constraint_args)
+
+                if is_satisfied is None:
+                    logger.error(
+                        f"An exception occurred running the checking the activity {self.name} constraint."
+                        + f" The constraint function failed to return True or False."
+                    )
             except Exception as e:
                 logger.error(
-                    f"An exception occurred running the checking the activity's {self.name} constraint."
+                    f"An exception occurred running the checking the activity {self.name} constraint."
                 )
                 logger.error(str(e))
                 return False
-            if not is_satisfied or is_satisfied is None:
+            if not is_satisfied:
                 logger.debug(
                     f"Constraint of activity {self.name} is no longer satisfied, cancelling."
                 )
                 if not self._was_stopped:
                     await self.stop()
-                return False
+            return False
         else:
             logger.warning(
                 f"Checking activity {self.name} constraints even though activity has no constraints."

--- a/paseos/activities/activity_runner.py
+++ b/paseos/activities/activity_runner.py
@@ -103,7 +103,7 @@ class ActivityRunner:
                 if is_satisfied is None:
                     logger.error(
                         f"An exception occurred running the checking the activity {self.name} constraint."
-                        + f" The constraint function failed to return True or False."
+                        + " The constraint function failed to return True or False."
                     )
             except Exception as e:
                 logger.error(

--- a/paseos/tests/activity_test.py
+++ b/paseos/tests/activity_test.py
@@ -11,6 +11,33 @@ async def wait_for_activity(sim):
         await asyncio.sleep(0.1)
 
 
+# @pytest.mark.asyncio
+# async def test_faulty_constraint_function():
+#     """Check whether specifying a wrong constraint function leads to an error"""
+
+#     sim, _, _ = get_default_instance()
+
+#     # A pointless activity
+#     async def func(args):
+#         await asyncio.sleep(1.5)
+
+#     # A constraint function that fails to return True or False
+#     async def constraint(args):
+#         pass
+
+#     # Register an activity that draws 10 watt per second
+#     sim.register_activity(
+#         "Testing",
+#         activity_function=func,
+#         constraint_function=constraint,
+#         power_consumption_in_watt=10,
+#     )
+
+#     # Run the activity
+#     sim.perform_activity("Testing")
+#     await wait_for_activity(sim)
+
+
 # tell pytest to create an event loop and execute the tests using the event loop
 @pytest.mark.asyncio
 async def test_activity():

--- a/paseos/tests/activity_test.py
+++ b/paseos/tests/activity_test.py
@@ -11,6 +11,9 @@ async def wait_for_activity(sim):
         await asyncio.sleep(0.1)
 
 
+# Below test can be used to check what happens when you formulate an invalid constraint function.
+# It is temporarily commented out as it doesn't really check right now because I could not figure
+# out a way to get an exception raised from the async code.
 # @pytest.mark.asyncio
 # async def test_faulty_constraint_function():
 #     """Check whether specifying a wrong constraint function leads to an error"""


### PR DESCRIPTION
# Description

Added error in log like this

![image](https://user-images.githubusercontent.com/2656685/207097863-5c91bfec-0e2b-4aaa-bf03-75f7a92da7f4.png)

@GabrieleMeoni I could not find a way to raise an exception inside the async functions. Instead I display an error like above, good enough for now I think?

The original problem of the termination function running twice, I think, was already solved before?

## Resolved Issues

- [x] fixes #44 

## How Has This Been Tested?

Specific test

## Related Pull Requests

N/A
