### PR TITLE
Pykep version bump to support 3.12

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -2,20 +2,20 @@ name: paseos
 channels:
   - conda-forge
 dependencies:
-  - dotmap>=1.3.30 # core non-optional dependency
-  - loguru>=0.6.0 # core non-optional dependency
-  - matplotlib>=3.6.0 # core non-optional dependency
-  - numpy==1.23.5 # core non-optional depedency
-  - myst-parser # for markdown math in docs
-  - pykep>=2.6 # core non-optional dependency
-  - pyquaternion>=0.9.9 # core non-optional dependency
-  - pytest # for tests
-  - pytest-asyncio # for tests involving activities
-  - python>=3.8 # core non-optional dependency
-  - scikit-spatial>=6.5.0 # core non-optional dependency
-  - skyfield>=1.45 # core non-optional dependency
-  - sphinx # for docs
-  - sphinx_rtd_theme # for docs
-  - toml>=0.10.2 # core non-optional dependency
-  - tqdm>=4.64.1 # core non-optional dependency
-  - trimesh>=4.0.7  # for geometric model
+  - python>=3.12  # Updated to support Python 3.12
+  - dotmap>=1.3.30  # Core non-optional dependency
+  - loguru>=0.6.0  # Core non-optional dependency
+  - matplotlib==3.10.0  # Core non-optional dependency
+  - numpy>=1.26.0  # Updated to latest major version for Python 3.12
+  - myst-parser  # For markdown math in docs
+  - pyquaternion>=0.9.9  # Core non-optional dependency
+  - pytest  # For tests
+  - pytest-asyncio  # For tests involving async activities
+  - scikit-spatial>=6.8.1  # Core non-optional dependency
+  - skyfield>=1.45  # Core non-optional dependency
+  - sphinx  # For docs
+  - sphinx_rtd_theme  # For docs
+  - toml>=0.10.2  # Core non-optional dependency
+  - tqdm>=4.64.1  # Core non-optional dependency
+  - trimesh>=4.0.7  # For geometric model
+  - pykep==2.6.4

--- a/paseos/central_body/central_body.py
+++ b/paseos/central_body/central_body.py
@@ -98,7 +98,7 @@ class CentralBody:
         Returns:
             bool: True if the central body blocks the sun
         """
-        logger.debug(f"Checking whether {actor} is in eclipse at {t}.")
+        logger.debug(f"Checking whether {actor} is in eclipse at {t.jd}.")
 
         # Compute central body position in solar reference frame
         r_central_body_heliocentric, _ = np.array(self._planet.eph(t))


### PR DESCRIPTION
# Description
Bumped pykep to 2.6.4 to support python 3.12 (https://github.com/esa/pykep/releases/tag/v2.6.4) 

Not sure where else I need to edit. 

Not currently possible with pip, since they haven't published any 3.12 fix to pypi

Summary of changes
* Version bump in environment.yml
* Fix of handling the pk.epoch in central_body.py to support new pykep version
## Resolved Issues

- not being able to use 3.12

## How Has This Been Tested?

pytest with current test files

- #PR
