### PR TITLE
fix: lazy + crash-safe epoch formatting in eclipse-check debug log

### DIFF
--- a/paseos/central_body/central_body.py
+++ b/paseos/central_body/central_body.py
@@ -98,7 +98,16 @@ class CentralBody:
         Returns:
             bool: True if the central body blocks the sun
         """
-        logger.debug(f"Checking whether {actor} is in eclipse at {t}.")
+        # Lazy + safe formatting: this runs every timestep, and
+        # str(pk.epoch) can raise RuntimeError (boost bad_lexical_cast)
+        # on some pykep builds at exact minute boundaries, e.g.
+        # str(pk.epoch(60.0 / 86400.0)). Format only when a DEBUG
+        # handler is active, and never let logging crash the sim.
+        logger.opt(lazy=True).debug(
+            "Checking whether {} is in eclipse at {}.",
+            lambda: actor,
+            lambda: _safe_epoch_str(t),
+        )
 
         # Compute central body position in solar reference frame
         r_central_body_heliocentric, _ = np.array(self._planet.eph(t))
@@ -210,3 +219,15 @@ class CentralBody:
         # Rotate point
         q = Quaternion(axis=self._rotation_axis, angle=angle)
         return q.rotate(point)
+
+def _safe_epoch_str(t) -> str:
+    """String representation of a pykep epoch that cannot raise.
+
+    Some pykep builds raise RuntimeError (boost bad_lexical_cast) in
+    str(epoch) for values at exact minute boundaries; fall back to the
+    raw mjd2000 value in that case.
+    """
+    try:
+        return str(t)
+    except RuntimeError:
+        return f"epoch(mjd2000={t.mjd2000!r})"


### PR DESCRIPTION
## Problem

`CentralBody.blocks_sun()` formats the actor and epoch into an f-string on **every timestep**:

```python
logger.debug(f"Checking whether {actor} is in eclipse at {t}.")
```

On some pykep builds — observed with conda-forge **pykep 2.6.4 (osx-arm64, Python 3.11)** — `str(pk.epoch)` raises `RuntimeError: bad lexical cast` for epochs at **exact minute boundaries**:

```python
>>> str(pykep.epoch(60.0 / 86400.0))
RuntimeError: bad lexical cast: source type value could not be interpreted as target
# 59.999999 s and 60.000001 s both format fine — only the exact boundary fails
```

Since any simulation with power devices calls the eclipse check each `advance_time()`, every such simulation crashes at its first minute boundary regardless of log level — the f-string evaluates eagerly even when no DEBUG handler is active.

## Fix

- Use `logger.opt(lazy=True)` with callables, so formatting only happens when a DEBUG record is actually emitted (also removes per-timestep string formatting from the hot path).
- Format the epoch through a `_safe_epoch_str()` fallback (`mjd2000` representation) so logging can never crash the simulation even at DEBUG level.

The underlying pykep formatting bug is being reported upstream separately; this change makes PASEOS robust against it either way.

## Verification

- `paseos/tests/`: **32 passed**, 1 failure in `thermal_model_test.py` which fails identically on clean master (pre-existing, unrelated — numeric assertion).
- Before the fix, `power_test.py::test_power_charging` crashed with the lexical-cast error on the affected pykep build; it passes after.
- 90-minute two-shell scenario (300 km actor, power devices, 60 s steps) runs clean without workarounds.

Environment: macOS arm64, Python 3.11, conda-forge pykep 2.6.4, paseos master.

Co-authored with Claude (Anthropic) during a constellation-design study that uses PASEOS for power/eclipse validation.